### PR TITLE
Build MudBlazor-based Vendr embed

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,15 @@
-# Vendr Embed (met Google Maps key ingebouwd)
+# Vendr Embed (MudBlazor)
 
-- Gebruik `index.html`, `assets/css/base.css`, `assets/js/app.js` uit deze bundel.
-- Vereist: bestaande `data/realtors.json` en gespiegelde feeds in `data/realtor-<uuid>.json` (of externe feed).
+Deze repository bevat een Blazor WebAssembly-embed gebouwd met de MudBlazor component library.
 
-Voorbeeld-URL:
-`https://<username>.github.io/<repo>/?realtor=vendr`
+## Projectstructuur
+- `src/Vendr.Embed/` – hoofdproject (Blazor WebAssembly + MudBlazor)
+- `data/` – JSON feeds (worden automatisch gebundeld naar `wwwroot/data` via de csproj)
+
+## Ontwikkeling
+1. Installeer .NET 8 SDK.
+2. Navigeer naar `src/Vendr.Embed`.
+3. Voer `dotnet restore` en `dotnet build` uit.
+4. Start lokaal met `dotnet run` of publiceer met `dotnet publish -c Release`.
+
+De embed leest standaard `?realtor=` uit de URL en past thema, logo, filters en kaarten aan op basis van de datafeeds.

--- a/src/Vendr.Embed/App.razor
+++ b/src/Vendr.Embed/App.razor
@@ -1,0 +1,34 @@
+<MudThemeProvider Theme="@_theme" @ref="_themeProvider">
+    <MudDialogProvider />
+    <MudSnackbarProvider />
+
+    <CascadingValue Value="this" IsFixed="true">
+        <Router AppAssembly="typeof(App).Assembly">
+            <Found Context="routeData">
+                <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+                <FocusOnNavigate RouteData="routeData" Selector="h1" />
+            </Found>
+            <NotFound>
+                <LayoutView Layout="typeof(MainLayout)">
+                    <MudContainer Class="py-8">
+                        <MudAlert Severity="Severity.Error" Elevation="2">
+                            Pagina niet gevonden.
+                        </MudAlert>
+                    </MudContainer>
+                </LayoutView>
+            </NotFound>
+        </Router>
+    </CascadingValue>
+</MudThemeProvider>
+
+@code {
+    private MudThemeProvider? _themeProvider;
+    private MudTheme _theme = new();
+
+    public async Task SetPaletteAsync(Palette palette)
+    {
+        if (_themeProvider is null) return;
+        _theme = _theme with { Palette = palette };
+        await _themeProvider.ApplyTheme(_theme);
+    }
+}

--- a/src/Vendr.Embed/Models/Listing.cs
+++ b/src/Vendr.Embed/Models/Listing.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace Vendr.Embed.Models;
+
+public class Listing
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("full_address")]
+    public string? FullAddress { get; set; }
+
+    [JsonPropertyName("province")]
+    public string? Province { get; set; }
+
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    [JsonPropertyName("location")]
+    public string? Location { get; set; }
+
+    [JsonPropertyName("asset_type")]
+    public string? AssetType { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("specifications")]
+    public string? Specifications { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("selling_procedure")]
+    public string? SellingProcedure { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("availability")]
+    public string? Availability { get; set; }
+
+    [JsonPropertyName("is_sold")]
+    public bool? IsSold { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("image")]
+    public string? Image { get; set; }
+
+    public string ComputedProvince { get; set; } = string.Empty;
+    public string ComputedType { get; set; } = string.Empty;
+}

--- a/src/Vendr.Embed/Models/ListingExtensions.cs
+++ b/src/Vendr.Embed/Models/ListingExtensions.cs
@@ -1,0 +1,99 @@
+using System.Text.RegularExpressions;
+
+namespace Vendr.Embed.Models;
+
+public static partial class ListingExtensions
+{
+    private static readonly string[] Provinces =
+    [
+        "Groningen","Friesland","Drenthe","Overijssel","Flevoland",
+        "Gelderland","Utrecht","Noord-Holland","Zuid-Holland","Zeeland",
+        "Noord-Brabant","Limburg"
+    ];
+
+    public static string NormalizeStatus(this Listing listing)
+    {
+        if (listing.IsSold is true) return "sold";
+
+        var availability = listing.Availability?.Trim().ToLowerInvariant();
+        if (availability == "sold") return "sold";
+        if (availability == "sold_stc") return "sold_stc";
+        if (availability == "under_bid") return "under_bid";
+
+        var status = listing.Status?.Trim().ToLowerInvariant();
+        if (!string.IsNullOrEmpty(status))
+        {
+            if (SoldRegex().IsMatch(status)) return "sold";
+            if (SoldStcRegex().IsMatch(status)) return "sold_stc";
+            if (UnderBidRegex().IsMatch(status)) return "under_bid";
+        }
+
+        return "available";
+    }
+
+    public static string StatusLabel(this Listing listing)
+        => listing.NormalizeStatus() switch
+        {
+            "sold" => "Verkocht",
+            "under_bid" => "Onder bod",
+            "sold_stc" => "Verkocht o.v.",
+            _ => "Beschikbaar"
+        };
+
+    public static void Enrich(this Listing listing)
+    {
+        listing.ComputedProvince = DetermineProvince(listing);
+        listing.ComputedType = DetermineType(listing);
+    }
+
+    private static string DetermineProvince(Listing listing)
+    {
+        var haystack = string.Join(' ', new[]
+        {
+            listing.Province,
+            listing.FullAddress,
+            listing.City,
+            listing.Location
+        }.Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        foreach (var province in Provinces)
+        {
+            if (haystack.Contains(province, StringComparison.OrdinalIgnoreCase))
+            {
+                return province;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string DetermineType(Listing listing)
+    {
+        var haystack = string.Join(' ', new[]
+        {
+            listing.AssetType,
+            listing.Type,
+            listing.Specifications,
+            listing.Description,
+            listing.SellingProcedure
+        }.Where(x => !string.IsNullOrWhiteSpace(x))).ToLowerInvariant();
+
+        if (haystack.Contains("kantoor")) return "Kantoor";
+        if (haystack.Contains("winkel")) return "Winkel";
+        if (haystack.Contains("logistiek") || haystack.Contains("bedrijfshal") || haystack.Contains("magazijn"))
+            return "Bedrijfsruimte";
+        if (haystack.Contains("bouwgrond") || haystack.Contains("grond"))
+            return "Grond";
+        if (haystack.Contains("horeca")) return "Horeca";
+        return "Overig";
+    }
+
+    [GeneratedRegex("verkocht(?!.*voorbehoud)")]
+    private static partial Regex SoldRegex();
+
+    [GeneratedRegex("verkocht.*voorbehoud")]
+    private static partial Regex SoldStcRegex();
+
+    [GeneratedRegex("onder.*bod")]
+    private static partial Regex UnderBidRegex();
+}

--- a/src/Vendr.Embed/Models/RealtorMap.cs
+++ b/src/Vendr.Embed/Models/RealtorMap.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Vendr.Embed.Models;
+
+public class RealtorMap
+{
+    [JsonPropertyName("generated_at")]
+    public DateTimeOffset? GeneratedAt { get; set; }
+
+    [JsonPropertyName("realtors")]
+    public Dictionary<string, RealtorMeta> Realtors { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class RealtorMeta
+{
+    [JsonPropertyName("uuid")]
+    public string? Uuid { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("feed")]
+    public string? Feed { get; set; }
+
+    [JsonPropertyName("stylesheet_local")]
+    public string? StylesheetLocal { get; set; }
+
+    [JsonPropertyName("website")]
+    public string? Website { get; set; }
+
+    [JsonPropertyName("logo")]
+    public string? Logo { get; set; }
+
+    [JsonPropertyName("color")]
+    public string? Color { get; set; }
+}

--- a/src/Vendr.Embed/Pages/Index.razor
+++ b/src/Vendr.Embed/Pages/Index.razor
@@ -1,0 +1,311 @@
+@page "/"
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+<PageTitle>@PageHeading</PageTitle>
+
+@if (_loading)
+{
+    <MudStack AlignItems="AlignItems.Center" Class="py-10" Spacing="3">
+        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
+        <MudText Typo="Typo.subtitle1">Gegevens worden geladen…</MudText>
+    </MudStack>
+}
+else if (!string.IsNullOrEmpty(_error))
+{
+    <MudAlert Severity="Severity.Error" Elevation="2" Class="my-6">
+        @_error
+    </MudAlert>
+}
+else
+{
+    <MudStack Spacing="3">
+        <MudPaper Class="pa-4" Elevation="1">
+            <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                <MudSelect T="string" @bind-Value="SelectedProvince" Label="Provincie" Clearable="true" Dense="true">
+                    <MudSelectItem Value="">Alle provincies</MudSelectItem>
+                    @foreach (var province in _availableProvinces)
+                    {
+                        <MudSelectItem Value="@province">@province</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudSelect T="string" @bind-Value="SelectedType" Label="Type vastgoed" Clearable="true" Dense="true">
+                    <MudSelectItem Value="">Alle typen</MudSelectItem>
+                    @foreach (var type in _availableTypes)
+                    {
+                        <MudSelectItem Value="@type">@type</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudSelect T="string" @bind-Value="SelectedStatus" Label="Status" Clearable="true" Dense="true">
+                    <MudSelectItem Value="">Alle statussen</MudSelectItem>
+                    @foreach (var option in _statusOptions)
+                    {
+                        <MudSelectItem Value="@option.Key">@option.Value</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudStack>
+        </MudPaper>
+
+        <MudText Typo="Typo.subtitle1" Style="font-weight:600;">
+            @_filtered.Count resultaat@(_filtered.Count == 1 ? string.Empty : "en")
+        </MudText>
+
+        <MudGrid GutterSize="GutterSize.Medium">
+            @foreach (var listing in _filtered)
+            {
+                <MudItem xs="12" sm="6" md="4" lg="3">
+                    <MudCard Elevation="1" Class="h-100 d-flex flex-column">
+                        <MudCardMedia Image="@GetImage(listing)" Height="180px" />
+                        <MudCardContent Class="d-flex flex-column gap-2">
+                            <MudChip Color="Color.Primary" Variant="Variant.Filled" Label="true">@listing.StatusLabel()</MudChip>
+                            <MudText Typo="Typo.h6" Class="mb-0">@listing.Name</MudText>
+                            <MudText Typo="Typo.body2" Class="text-secondary">@listing.FullAddress</MudText>
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="text-caption text-secondary">
+                                <MudIcon Icon="@Icons.Material.Filled.Place" Size="Size.Small" />
+                                <MudText Typo="Typo.caption">@listing.ComputedProvince</MudText>
+                            </MudStack>
+                        </MudCardContent>
+                        <MudCardActions Class="mt-auto">
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="@listing.Url" Target="_blank" Rel="noopener">
+                                Bekijk op Vendr
+                                <MudIcon Icon="@Icons.Material.Filled.OpenInNew" Class="ml-1" Size="Size.Small" />
+                            </MudButton>
+                        </MudCardActions>
+                    </MudCard>
+                </MudItem>
+            }
+        </MudGrid>
+    </MudStack>
+}
+
+@code {
+    private const string PlaceholderImage = "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 300'%3E%3Crect width='400' height='300' fill='%23e5e7eb'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Arial' font-size='16' fill='%23111827'%3EGeen afbeelding%3C/text%3E%3C/svg%3E";
+
+    private readonly IReadOnlyDictionary<string, string> _statusOptions = new Dictionary<string, string>
+    {
+        ["available"] = "Beschikbaar",
+        ["under_bid"] = "Onder bod",
+        ["sold_stc"] = "Verkocht o.v.",
+        ["sold"] = "Verkocht"
+    };
+
+    private readonly List<Listing> _listings = new();
+    private readonly List<Listing> _filtered = new();
+    private readonly List<string> _availableProvinces = new();
+    private readonly List<string> _availableTypes = new();
+
+    private string? _selectedProvince;
+    private string? _selectedType;
+    private string? _selectedStatus;
+    private string? _error;
+    private bool _loading = true;
+    private RealtorMeta? _meta;
+
+    private string PageHeading => _meta?.Name ?? "Vendr Embed";
+
+    [CascadingParameter]
+    public App? RootApp { get; set; }
+
+    [CascadingParameter]
+    public MainLayout? Layout { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            await LoadDataAsync();
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private RenderFragment HeaderFragment => @<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+        @if (!string.IsNullOrEmpty(_meta?.Logo))
+        {
+            <MudAvatar Size="Size.Medium" Image="@_meta.Logo" Alt="@_meta?.Name" />
+        }
+        <MudStack Spacing="0.5">
+            <MudText Typo="Typo.h6">@PageHeading</MudText>
+            @if (!string.IsNullOrWhiteSpace(_meta?.Website))
+            {
+                <MudLink Href="@FormatWebsite(_meta!.Website!)" Target="_blank" Rel="noopener">@_meta!.Website</MudLink>
+            }
+        </MudStack>
+    </MudStack>;
+
+    private async Task LoadDataAsync()
+    {
+        var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+        query.TryGetValue("realtor", out var realtorValues);
+        var realtorKey = realtorValues.FirstOrDefault()?.Trim().ToLowerInvariant();
+
+        query.TryGetValue("feed", out var feedValues);
+        var overrideFeed = feedValues.FirstOrDefault()?.Trim();
+
+        if (string.IsNullOrWhiteSpace(realtorKey) && string.IsNullOrWhiteSpace(overrideFeed))
+        {
+            throw new InvalidOperationException("Gebruik de parameter ?realtor= of ?feed= om een makelaar te tonen.");
+        }
+
+        IReadOnlyList<Listing> listings;
+
+        if (!string.IsNullOrWhiteSpace(overrideFeed))
+        {
+            listings = await FetchListingsAsync(overrideFeed!);
+        }
+        else
+        {
+            listings = await LoadFromMappingAsync(realtorKey!);
+        }
+
+        foreach (var listing in listings)
+        {
+            listing.Enrich();
+            _listings.Add(listing);
+        }
+
+        _availableProvinces.AddRange(_listings.Select(l => l.ComputedProvince).Where(s => !string.IsNullOrWhiteSpace(s)).Distinct(StringComparer.OrdinalIgnoreCase));
+        _availableTypes.AddRange(_listings.Select(l => l.ComputedType).Where(s => !string.IsNullOrWhiteSpace(s)).Distinct(StringComparer.OrdinalIgnoreCase));
+
+        _availableProvinces.Sort(StringComparer.OrdinalIgnoreCase);
+        _availableTypes.Sort(StringComparer.OrdinalIgnoreCase);
+
+        ApplyFilters();
+
+        if (_meta is not null)
+        {
+            Layout?.SetHeader(HeaderFragment);
+
+            if (!string.IsNullOrWhiteSpace(_meta.Color) && RootApp is not null)
+            {
+                var palette = new Palette
+                {
+                    Primary = _meta.Color,
+                    Secondary = _meta.Color,
+                    AppbarBackground = _meta.Color,
+                    AppbarText = "#ffffff"
+                };
+
+                await RootApp.SetPaletteAsync(palette);
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<Listing>> FetchListingsAsync(string url)
+    {
+        var result = await Http.GetFromJsonAsync<List<Listing>>(url);
+        if (result is null)
+        {
+            throw new InvalidOperationException($"Kon feed niet laden: {url}");
+        }
+        return result;
+    }
+
+    private async Task<IReadOnlyList<Listing>> LoadFromMappingAsync(string realtorKey)
+    {
+        var map = await Http.GetFromJsonAsync<RealtorMap>("data/realtors.json");
+        if (map?.Realtors is null)
+        {
+            throw new InvalidOperationException("Bestand data/realtors.json is ongeldig of mist.");
+        }
+
+        if (!map.Realtors.TryGetValue(realtorKey, out var meta))
+        {
+            throw new InvalidOperationException($"Onbekende makelaar \"{realtorKey}\".");
+        }
+
+        _meta = meta;
+
+        if (!string.IsNullOrWhiteSpace(meta.Uuid))
+        {
+            var localPath = $"data/realtor-{meta.Uuid}.json";
+            try
+            {
+                return await FetchListingsAsync(localPath);
+            }
+            catch
+            {
+                // val terug op externe feed
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(meta.Feed))
+        {
+            return await FetchListingsAsync(meta.Feed);
+        }
+
+        throw new InvalidOperationException("Geen geldige feed gevonden voor deze makelaar.");
+    }
+
+    private void ApplyFilters()
+    {
+        _filtered.Clear();
+
+        foreach (var listing in _listings)
+        {
+            if (!string.IsNullOrEmpty(_selectedProvince) && !string.Equals(listing.ComputedProvince, _selectedProvince, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(_selectedType) && !string.Equals(listing.ComputedType, _selectedType, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var status = listing.NormalizeStatus();
+            if (!string.IsNullOrEmpty(_selectedStatus) && !string.Equals(status, _selectedStatus, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            _filtered.Add(listing);
+        }
+    }
+
+    private string GetImage(Listing listing)
+        => string.IsNullOrWhiteSpace(listing.Image) ? PlaceholderImage : listing.Image;
+
+    private string FormatWebsite(string website)
+        => website.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? website : $"https://{website}";
+
+    private string? SelectedProvince
+    {
+        get => _selectedProvince;
+        set
+        {
+            _selectedProvince = string.IsNullOrWhiteSpace(value) ? null : value;
+            ApplyFilters();
+        }
+    }
+
+    private string? SelectedType
+    {
+        get => _selectedType;
+        set
+        {
+            _selectedType = string.IsNullOrWhiteSpace(value) ? null : value;
+            ApplyFilters();
+        }
+    }
+
+    private string? SelectedStatus
+    {
+        get => _selectedStatus;
+        set
+        {
+            _selectedStatus = string.IsNullOrWhiteSpace(value) ? null : value;
+            ApplyFilters();
+        }
+    }
+}

--- a/src/Vendr.Embed/Program.cs
+++ b/src/Vendr.Embed/Program.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using MudBlazor.Services;
+using Vendr.Embed;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddMudServices();
+
+await builder.Build().RunAsync();

--- a/src/Vendr.Embed/Shared/MainLayout.razor
+++ b/src/Vendr.Embed/Shared/MainLayout.razor
@@ -1,0 +1,34 @@
+@inherits LayoutComponentBase
+
+<MudLayout>
+    <MudAppBar Elevation="0" Color="Color.Primary" Dense="true" DisableShrink="true">
+        <MudContainer Class="d-flex align-center justify-space-between" MaxWidth="MaxWidth.False">
+            @if (_headerContent is not null)
+            {
+                @_headerContent
+            }
+            else
+            {
+                <MudText Typo="Typo.h6">Vendr Embed</MudText>
+            }
+        </MudContainer>
+    </MudAppBar>
+
+    <MudMainContent>
+        <MudContainer Class="py-6" MaxWidth="MaxWidth.False">
+            <CascadingValue Value="this">
+                @Body
+            </CascadingValue>
+        </MudContainer>
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private RenderFragment? _headerContent;
+
+    public void SetHeader(RenderFragment? fragment)
+    {
+        _headerContent = fragment;
+        _ = InvokeAsync(StateHasChanged);
+    }
+}

--- a/src/Vendr.Embed/Vendr.Embed.csproj
+++ b/src/Vendr.Embed/Vendr.Embed.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
+    <PackageReference Include="MudBlazor" Version="7.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="../../data/**/*.json">
+      <Link>wwwroot/data/%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Vendr.Embed/_Imports.razor
+++ b/src/Vendr.Embed/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.JSInterop
+@using MudBlazor
+@using Vendr.Embed
+@using Vendr.Embed.Models

--- a/src/Vendr.Embed/wwwroot/css/app.css
+++ b/src/Vendr.Embed/wwwroot/css/app.css
@@ -1,0 +1,13 @@
+body {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background-color: #f5f7fa;
+}
+
+.mud-container {
+    max-width: 1200px;
+}
+
+.mud-card .mud-card-content {
+    flex-grow: 1;
+}

--- a/src/Vendr.Embed/wwwroot/index.html
+++ b/src/Vendr.Embed/wwwroot/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vendr Embed</title>
+    <base href="/" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="Vendr.Embed.styles.css" />
+</head>
+<body>
+    <div id="app">Laden…</div>
+
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the static embed with a Blazor WebAssembly project that uses MudBlazor components
- implement realtor/theme loading, filtering, and card rendering with strongly-typed models
- include linked JSON data, base styling, and updated documentation for running the new embed

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68deed7bcdd08329b053fa134c60f1e4