### PR TITLE
Fix filter panel visibility

### DIFF
--- a/src/Vendr.Embed/Pages/Index.razor.css
+++ b/src/Vendr.Embed/Pages/Index.razor.css
@@ -6,6 +6,7 @@
 
 .filters-panel {
     width: 280px;
+    flex: 0 0 280px;
     transition: width 0.25s ease, padding 0.25s ease;
     overflow: hidden;
 }
@@ -20,6 +21,7 @@
 
 .filters-panel.collapsed {
     width: 56px;
+    flex: 0 0 56px;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
 }


### PR DESCRIPTION
## Summary
- prevent the filters panel from shrinking out of view by locking its flex basis
- ensure the collapsed state also reserves space for the toggle button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68defa06c0288329a305a1c8372b229f