### PR TITLE
Load realtor theme defaults into style controls

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -24,6 +24,23 @@ body {
 main.container.themed {
   --card-shadow: none;
   --media-ratio: 58%;
+  --card-aspect: 7 / 8;
+  --badge-padding: 10px;
+  --badge-offset: 12px;
+  --badge-radius: 4px;
+  --badge-text: #052e16;
+  --badge-color: #22c55e;
+  --button-padding: 14px;
+  --button-offset: 16px;
+  --button-radius: 40px;
+  --button-shadow: none;
+  --button-text: #ffffff;
+  --title-color: #0f172a;
+  --general-text: #475569;
+  --font-body: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  --font-heading: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  --font-label: var(--font-body);
+  --font-button: var(--font-body);
 }
 
 .themed-layout {
@@ -69,6 +86,11 @@ main.container.themed {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.style-panel,
+.style-panel * {
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial !important;
 }
 
 .style-panel__section {
@@ -235,7 +257,7 @@ header, .header--neutral, .header-bar { transform: translateZ(0); }
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  aspect-ratio: 7 / 8; /* 7 breed, 8 hoog */
+  aspect-ratio: var(--card-aspect, 7 / 8);
   box-shadow: var(--card-shadow, none);
 }
 
@@ -257,14 +279,15 @@ header, .header--neutral, .header-bar { transform: translateZ(0); }
 
 .badge {
   position: absolute;
-  left: 12px;
-  top: 12px;
-  padding: 6px 10px;
-  border-radius: 4px;
+  left: var(--badge-offset, 12px);
+  top: var(--badge-offset, 12px);
+  padding: calc(var(--badge-padding, 10px) * 0.6) var(--badge-padding, 10px);
+  border-radius: var(--badge-radius, 4px);
   font-weight: 700;
   font-size: 12px;
   background: var(--badge-color, #22c55e);
   color: var(--badge-text, #052e16);
+  font-family: var(--font-label, var(--font-body));
   z-index: 0;
 }
 .badge.warn { background: var(--warn); color: #2b1710; }
@@ -272,37 +295,40 @@ header, .header--neutral, .header-bar { transform: translateZ(0); }
 
 .body {
   padding: 14px 16px;
-  font: 0.9em 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  font: 0.9em var(--font-body, 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial);
   flex: 1 1 auto;
 }
 
 .name {
   margin: 0 0 6px;
-  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  font-family: var(--font-heading, 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial);
   font-weight: 700;
   font-size: 1.17em;
   line-height: 1.3;
+  color: var(--title-color, #0f172a);
 }
 
-.addr { margin: 0; color: var(--muted); }
-.meta { margin: 8px 0 0; color: var(--muted); font-size: .85em; }
+.addr { margin: 0; color: var(--general-text, var(--muted)); }
+.meta { margin: 8px 0 0; color: var(--general-text, var(--muted)); font-size: .85em; }
 
 .actions {
   display: flex;
   gap: 10px;
-  padding: 12px 16px;
+  padding: calc(var(--button-offset, 16px) * 0.75) var(--button-offset, 16px);
   margin-top: auto; /* altijd onderaan */
 }
 
 .actions .btn {
-  border-radius: 999px;
-  padding: 10px 14px;
+  border-radius: var(--button-radius, 40px);
+  padding: calc(var(--button-padding, 14px) * 0.7) var(--button-padding, 14px);
   background: var(--accent);
-  color: #fff;
+  color: var(--button-text, #fff);
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  box-shadow: var(--button-shadow, none);
+  font-family: var(--font-button, var(--font-body));
 }
 .actions .btn .ext { display: block; }
 

--- a/index.html
+++ b/index.html
@@ -77,24 +77,59 @@
         <form class="style-panel__form" autocomplete="off">
           <fieldset class="style-panel__section">
             <legend>Kleuren</legend>
-            <label class="style-panel__field" for="stylePrimaryColor">
-              <span>Primaire kleur</span>
-              <input type="color" id="stylePrimaryColor" name="stylePrimaryColor"
-                     data-css-prop="--c-primary --c-accent --accent"
-                     value="#012d55" />
+            <label class="style-panel__field" for="styleButtonColor">
+              <span>Knop</span>
+              <input type="color" id="styleButtonColor" name="styleButtonColor"
+                     data-css-prop="--accent --c-accent"
+                     data-sample-selector=".card .actions .btn" data-sample-prop="background-color"
+                     value="#2563eb" />
             </label>
 
-            <label class="style-panel__field" for="styleAccentColor">
-              <span>Accentkleur</span>
-              <input type="color" id="styleAccentColor" name="styleAccentColor"
-                     data-css-prop="--c-pill --badge-color"
-                     value="#5d3d69" />
+            <label class="style-panel__field" for="styleBadgeColor">
+              <span>Label</span>
+              <input type="color" id="styleBadgeColor" name="styleBadgeColor"
+                     data-css-prop="--badge-color --c-pill"
+                     data-sample-selector=".card .media .badge" data-sample-prop="background-color"
+                     value="#22c55e" />
+            </label>
+
+            <label class="style-panel__field" for="styleLabelTextColor">
+              <span>Tekst label</span>
+              <input type="color" id="styleLabelTextColor" name="styleLabelTextColor"
+                     data-css-prop="--badge-text"
+                     data-sample-selector=".card .media .badge" data-sample-prop="color"
+                     value="#052e16" />
+            </label>
+
+            <label class="style-panel__field" for="styleButtonTextColor">
+              <span>Tekst knop</span>
+              <input type="color" id="styleButtonTextColor" name="styleButtonTextColor"
+                     data-css-prop="--button-text"
+                     data-sample-selector=".card .actions .btn" data-sample-prop="color"
+                     value="#ffffff" />
+            </label>
+
+            <label class="style-panel__field" for="styleTitleTextColor">
+              <span>Tekst titel</span>
+              <input type="color" id="styleTitleTextColor" name="styleTitleTextColor"
+                     data-css-prop="--title-color --c-primary"
+                     data-sample-selector=".card .body .name" data-sample-prop="color"
+                     value="#0f172a" />
+            </label>
+
+            <label class="style-panel__field" for="styleGeneralTextColor">
+              <span>Tekst algemeen</span>
+              <input type="color" id="styleGeneralTextColor" name="styleGeneralTextColor"
+                     data-css-prop="--general-text --c-text --c-addr --c-muted"
+                     data-sample-selector=".card .body .addr" data-sample-prop="color"
+                     value="#475569" />
             </label>
 
             <label class="style-panel__field" for="styleCardColor">
               <span>Kaart achtergrond</span>
               <input type="color" id="styleCardColor" name="styleCardColor"
                      data-css-prop="--c-card"
+                     data-sample-selector=".card" data-sample-prop="background-color"
                      value="#ffffff" />
             </label>
           </fieldset>
@@ -102,8 +137,8 @@
           <fieldset class="style-panel__section">
             <legend>Typografie</legend>
             <label class="style-panel__field" for="styleBodyFont">
-              <span>Bodyfont</span>
-              <select id="styleBodyFont" data-font-target="body">
+              <span>Algemeen</span>
+              <select id="styleBodyFont" data-font-target="body" data-font-selector=".card .body">
                 <option value="inter">Inter</option>
                 <option value="roboto">Roboto</option>
                 <option value="roboto-slab">Roboto Slab</option>
@@ -111,21 +146,50 @@
             </label>
 
             <label class="style-panel__field" for="styleHeadingFont">
-              <span>Kopfont</span>
-              <select id="styleHeadingFont" data-font-target="heading">
+              <span>Titel</span>
+              <select id="styleHeadingFont" data-font-target="heading" data-font-selector=".card .body .name">
                 <option value="roboto-slab">Roboto Slab</option>
                 <option value="inter">Inter</option>
                 <option value="roboto">Roboto</option>
+              </select>
+            </label>
+
+            <label class="style-panel__field" for="styleLabelFont">
+              <span>Label</span>
+              <select id="styleLabelFont" data-font-target="label" data-font-selector=".card .media .badge">
+                <option value="inter">Inter</option>
+                <option value="roboto">Roboto</option>
+                <option value="roboto-slab">Roboto Slab</option>
+              </select>
+            </label>
+
+            <label class="style-panel__field" for="styleButtonFont">
+              <span>Knop</span>
+              <select id="styleButtonFont" data-font-target="button" data-font-selector=".card .actions .btn">
+                <option value="inter">Inter</option>
+                <option value="roboto">Roboto</option>
+                <option value="roboto-slab">Roboto Slab</option>
               </select>
             </label>
           </fieldset>
 
           <fieldset class="style-panel__section">
             <legend>Kaartopmaak</legend>
+            <label class="style-panel__field" for="styleAspectRatio">
+              <span>Verhouding</span>
+              <select id="styleAspectRatio" data-aspect-select>
+                <option value="2 / 3">2/3</option>
+                <option value="3 / 4">3/4</option>
+                <option value="5 / 7">5/7</option>
+                <option value="7 / 8" selected>7/8</option>
+              </select>
+            </label>
+
             <label class="style-panel__field" for="styleRadius">
-              <span>Hoekradius</span>
+              <span>Hoekradius kaart</span>
               <input type="range" id="styleRadius" min="0" max="32" step="2" value="14"
-                     data-css-prop="--radius" data-unit="px" />
+                     data-css-prop="--radius" data-unit="px"
+                     data-sample-selector=".card" data-sample-prop="border-top-left-radius" />
             </label>
 
             <label class="style-panel__field" for="styleMediaRatio">
@@ -134,10 +198,58 @@
                      data-css-prop="--media-ratio" data-unit="%" />
             </label>
 
+            <label class="style-panel__field" for="styleBadgeSize">
+              <span>Afmeting label</span>
+              <input type="range" id="styleBadgeSize" min="6" max="28" step="1" value="10"
+                     data-css-prop="--badge-padding" data-unit="px"
+                     data-sample-selector=".card .media .badge" data-sample-prop="padding-right" />
+            </label>
+
+            <label class="style-panel__field" for="styleButtonSize">
+              <span>Afmeting knop</span>
+              <input type="range" id="styleButtonSize" min="10" max="36" step="1" value="14"
+                     data-css-prop="--button-padding" data-unit="px"
+                     data-sample-selector=".card .actions .btn" data-sample-prop="padding-right" />
+            </label>
+
+            <label class="style-panel__field" for="styleBadgeOffset">
+              <span>Afstand label</span>
+              <input type="range" id="styleBadgeOffset" min="0" max="64" step="1" value="12"
+                     data-css-prop="--badge-offset" data-unit="px"
+                     data-sample-selector=".card .media .badge" data-sample-prop="left" />
+            </label>
+
+            <label class="style-panel__field" for="styleButtonOffset">
+              <span>Afstand knop</span>
+              <input type="range" id="styleButtonOffset" min="0" max="64" step="1" value="16"
+                     data-css-prop="--button-offset" data-unit="px"
+                     data-sample-selector=".card .actions" data-sample-prop="padding-right" />
+            </label>
+
+            <label class="style-panel__field" for="styleBadgeRadius">
+              <span>Hoekradius label</span>
+              <input type="range" id="styleBadgeRadius" min="0" max="48" step="1" value="4"
+                     data-css-prop="--badge-radius" data-unit="px"
+                     data-sample-selector=".card .media .badge" data-sample-prop="border-top-left-radius" />
+            </label>
+
+            <label class="style-panel__field" for="styleButtonRadius">
+              <span>Hoekradius knop</span>
+              <input type="range" id="styleButtonRadius" min="0" max="120" step="1" value="40"
+                     data-css-prop="--button-radius" data-unit="px"
+                     data-sample-selector=".card .actions .btn" data-sample-prop="border-radius" />
+            </label>
+
             <label class="style-panel__field" for="styleElevation">
-              <span>Schaduw</span>
+              <span>Schaduw kaart</span>
               <input type="range" id="styleElevation" min="0" max="12" step="1" value="4"
                      data-elevation />
+            </label>
+
+            <label class="style-panel__field" for="styleButtonShadow">
+              <span>Schaduw knop</span>
+              <input type="range" id="styleButtonShadow" min="0" max="12" step="1" value="4"
+                     data-button-shadow />
             </label>
 
             <label class="style-panel__toggle" for="styleOutline">


### PR DESCRIPTION
## Summary
- load the realtor-specific stylesheet when present, falling back to the default theme when the file is missing or empty
- install override styles so theme variables drive the cards while keeping the edit panel fonts fixed to Inter
- expand the style panel with additional colour, typography, layout and shadow controls that read current values from the active theme

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68df13a9e5888329b8f02df56ca5930d