### PR TITLE
Replace style panel with slide-in menu

### DIFF
--- a/src/Vendr.Embed/Pages/Index.razor
+++ b/src/Vendr.Embed/Pages/Index.razor
@@ -67,9 +67,18 @@ else
             </MudPaper>
 
             <MudStack Class="main-column" Spacing="2" Style="@MainFontStyle">
-                <MudText Typo="Typo.subtitle1" Class="font-semibold">
-                    @_filtered.Count resultaat@(_filtered.Count == 1 ? string.Empty : "en")
-                </MudText>
+                <MudStack Row="true" AlignItems="AlignItems.Center" JustifyContent="Justify.SpaceBetween" Class="main-toolbar">
+                    <MudText Typo="Typo.subtitle1" Class="font-semibold">
+                        @_filtered.Count resultaat@(_filtered.Count == 1 ? string.Empty : "en")
+                    </MudText>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Tune"
+                               OnClick="OpenStyleMenu"
+                               Class="style-menu-button">
+                        Stijlmenu
+                    </MudButton>
+                </MudStack>
 
                 <MudGrid GutterSize="GutterSize.Medium">
                     @foreach (var listing in _filtered)
@@ -97,72 +106,77 @@ else
                     }
                 </MudGrid>
             </MudStack>
-
-            <MudPaper Class="style-panel pa-4" Elevation="1">
-                <MudStack Spacing="1.5">
-                    <MudStack Spacing="0.5">
-                        <MudText Typo="Typo.subtitle2">Stijl</MudText>
-                        <MudText Typo="Typo.caption" Class="text-secondary">Pas de kleuren en kaarten visueel aan.</MudText>
-                    </MudStack>
-                    <MudDivider />
-
-                    <MudTreeView ExpandOnClick="true">
-                        <MudTreeViewItem Text="Kleuren" @bind-Expanded="ColorsExpanded">
-                            <Content>
-                                <MudStack Spacing="0.75" Class="mt-2">
-                                    <MudStack Spacing="0.75">
-                                        <MudText Typo="Typo.caption" Class="font-semibold">Primaire kleur</MudText>
-                                        <MudColorPicker @bind-Color="PrimaryColor" DisableAlpha="true" PickerVariant="PickerVariant.Static" Class="color-picker" />
-                                    </MudStack>
-
-                                    <MudStack Spacing="0.75">
-                                        <MudText Typo="Typo.caption" Class="font-semibold">Accentkleur</MudText>
-                                        <MudColorPicker @bind-Color="SecondaryColor" DisableAlpha="true" PickerVariant="PickerVariant.Static" Class="color-picker" />
-                                    </MudStack>
-                                </MudStack>
-                            </Content>
-                        </MudTreeViewItem>
-
-                        <MudTreeViewItem Text="Typografie" @bind-Expanded="TypographyExpanded">
-                            <Content>
-                                <MudStack Spacing="0.75" Class="mt-2">
-                                    <MudText Typo="Typo.caption" Class="font-semibold">Lettertype</MudText>
-                                    <MudSelect T="string" @bind-Value="_selectedFontKey" Dense="true" DisableUnderLine="true">
-                                        @foreach (var option in _fontOptions)
-                                        {
-                                            <MudSelectItem Value="@option.Key">@option.Key</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </MudStack>
-                            </Content>
-                        </MudTreeViewItem>
-
-                        <MudTreeViewItem Text="Kaartopmaak" @bind-Expanded="CardLayoutExpanded">
-                            <Content>
-                                <MudStack Spacing="0.75" Class="mt-2">
-                                    <MudStack Spacing="0.75">
-                                        <MudText Typo="Typo.caption" Class="font-semibold">Kaart-elevatie</MudText>
-                                        <MudSlider T="int" @bind-Value="_cardElevation" Min="0" Max="12" Step="1" Color="Color.Primary" ValueLabel="true" />
-                                    </MudStack>
-
-                                    <MudStack Spacing="0.75">
-                                        <MudText Typo="Typo.caption" Class="font-semibold">Hoekradius</MudText>
-                                        <MudSlider T="int" @bind-Value="_cardCornerRadius" Min="0" Max="32" Step="2" Color="Color.Primary" ValueLabel="true" />
-                                    </MudStack>
-
-                                    <MudStack Spacing="0.75">
-                                        <MudText Typo="Typo.caption" Class="font-semibold">Afbeelding hoogte</MudText>
-                                        <MudSlider T="int" @bind-Value="_cardImageHeight" Min="140" Max="260" Step="10" Color="Color.Primary" ValueLabel="true" />
-                                    </MudStack>
-
-                                    <MudSwitch @bind-Checked="_cardOutlined" Color="Color.Primary" Label="Rand zichtbaar" />
-                                </MudStack>
-                            </Content>
-                        </MudTreeViewItem>
-                    </MudTreeView>
-                </MudStack>
-            </MudPaper>
         </MudStack>
+        @if (_styleMenuOpen)
+        {
+            <div class="style-sidenav-backdrop" @onclick="CloseStyleMenu"></div>
+        }
+
+        <div class="style-sidenav @(_styleMenuOpen ? "open" : string.Empty)">
+            <button type="button" class="closebtn" @onclick="CloseStyleMenu">&times;</button>
+            <MudStack Spacing="1.5" Class="style-sidenav-content">
+                <MudStack Spacing="0.5">
+                    <MudText Typo="Typo.subtitle2">Stijl</MudText>
+                    <MudText Typo="Typo.caption" Class="text-secondary">Pas de kleuren en kaarten visueel aan.</MudText>
+                </MudStack>
+                <MudDivider />
+
+                <MudTreeView ExpandOnClick="true">
+                    <MudTreeViewItem Text="Kleuren" @bind-Expanded="ColorsExpanded">
+                        <Content>
+                            <MudStack Spacing="0.75" Class="mt-2">
+                                <MudStack Spacing="0.75">
+                                    <MudText Typo="Typo.caption" Class="font-semibold">Primaire kleur</MudText>
+                                    <MudColorPicker @bind-Color="PrimaryColor" DisableAlpha="true" PickerVariant="PickerVariant.Static" Class="color-picker" />
+                                </MudStack>
+
+                                <MudStack Spacing="0.75">
+                                    <MudText Typo="Typo.caption" Class="font-semibold">Accentkleur</MudText>
+                                    <MudColorPicker @bind-Color="SecondaryColor" DisableAlpha="true" PickerVariant="PickerVariant.Static" Class="color-picker" />
+                                </MudStack>
+                            </MudStack>
+                        </Content>
+                    </MudTreeViewItem>
+
+                    <MudTreeViewItem Text="Typografie" @bind-Expanded="TypographyExpanded">
+                        <Content>
+                            <MudStack Spacing="0.75" Class="mt-2">
+                                <MudText Typo="Typo.caption" Class="font-semibold">Lettertype</MudText>
+                                <MudSelect T="string" @bind-Value="_selectedFontKey" Dense="true" DisableUnderLine="true">
+                                    @foreach (var option in _fontOptions)
+                                    {
+                                        <MudSelectItem Value="@option.Key">@option.Key</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudStack>
+                        </Content>
+                    </MudTreeViewItem>
+
+                    <MudTreeViewItem Text="Kaartopmaak" @bind-Expanded="CardLayoutExpanded">
+                        <Content>
+                            <MudStack Spacing="0.75" Class="mt-2">
+                                <MudStack Spacing="0.75">
+                                    <MudText Typo="Typo.caption" Class="font-semibold">Kaart-elevatie</MudText>
+                                    <MudSlider T="int" @bind-Value="_cardElevation" Min="0" Max="12" Step="1" Color="Color.Primary" ValueLabel="true" />
+                                </MudStack>
+
+                                <MudStack Spacing="0.75">
+                                    <MudText Typo="Typo.caption" Class="font-semibold">Hoekradius</MudText>
+                                    <MudSlider T="int" @bind-Value="_cardCornerRadius" Min="0" Max="32" Step="2" Color="Color.Primary" ValueLabel="true" />
+                                </MudStack>
+
+                                <MudStack Spacing="0.75">
+                                    <MudText Typo="Typo.caption" Class="font-semibold">Afbeelding hoogte</MudText>
+                                    <MudSlider T="int" @bind-Value="_cardImageHeight" Min="140" Max="260" Step="10" Color="Color.Primary" ValueLabel="true" />
+                                </MudStack>
+
+                                <MudSwitch @bind-Checked="_cardOutlined" Color="Color.Primary" Label="Rand zichtbaar" />
+                            </MudStack>
+                        </Content>
+                    </MudTreeViewItem>
+                </MudTreeView>
+            </MudStack>
+        </div>
     </MudStack>
 }
 
@@ -193,6 +207,7 @@ else
     private string? _selectedStatus;
     private bool _filtersCollapsed;
     private bool _cardOutlined;
+    private bool _styleMenuOpen;
     private int _cardElevation = 1;
     private int _cardCornerRadius = 12;
     private int _cardImageHeight = 180;
@@ -447,6 +462,16 @@ else
     private void ToggleFilters()
     {
         _filtersCollapsed = !_filtersCollapsed;
+    }
+
+    private void OpenStyleMenu()
+    {
+        _styleMenuOpen = true;
+    }
+
+    private void CloseStyleMenu()
+    {
+        _styleMenuOpen = false;
     }
 
     private void InitializeStyleFromMeta(RealtorMeta meta)

--- a/src/Vendr.Embed/Pages/Index.razor.css
+++ b/src/Vendr.Embed/Pages/Index.razor.css
@@ -47,26 +47,82 @@
     font-weight: 600;
 }
 
-.style-panel {
-    width: 320px;
-    flex: 0 0 320px;
-    background-color: var(--mud-palette-grey-lighten-4, rgba(0, 0, 0, 0.04));
-    border-radius: 12px;
+
+.main-toolbar {
+    gap: 1rem;
 }
 
-.style-panel .mud-slider {
+.style-menu-button {
+    white-space: nowrap;
+}
+
+.style-sidenav {
+    height: 100%;
+    width: 0;
+    position: fixed;
+    z-index: 1200;
+    top: 0;
+    left: 0;
+    background-color: var(--mud-palette-background, #111);
+    overflow-x: hidden;
+    transition: width 0.3s ease;
+    padding-top: 64px;
+    display: flex;
+    flex-direction: column;
+}
+
+.style-sidenav.open {
+    width: min(360px, 90vw);
+}
+
+.style-sidenav .closebtn {
+    position: absolute;
+    top: 16px;
+    right: 24px;
+    font-size: 2rem;
+    color: var(--mud-palette-text-primary, #ffffff);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+}
+
+.style-sidenav-content {
+    padding: 0 1.75rem 2rem 1.75rem;
+    color: var(--mud-palette-text-primary, #f1f1f1);
+}
+
+.style-sidenav-content .mud-paper,
+.style-sidenav-content .mud-stack,
+.style-sidenav-content .mud-typography,
+.style-sidenav-content .mud-divider {
+    color: inherit;
+}
+
+.style-sidenav .mud-tree-view-item__content {
+    color: inherit;
+}
+
+.style-sidenav .mud-typography.text-secondary {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.style-sidenav .mud-slider,
+.style-sidenav .color-picker {
     margin-top: 0.25rem;
 }
 
-.style-panel .color-picker {
+.style-sidenav .color-picker {
     width: 100%;
 }
 
+.style-sidenav-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 1100;
+}
+
 @media (max-width: 1279px) {
-    .style-panel {
-        width: 280px;
-        flex: 0 0 280px;
-    }
 }
 
 @media (max-width: 960px) {
@@ -75,8 +131,7 @@
     }
 
     .filters-panel,
-    .filters-panel.collapsed,
-    .style-panel {
+    .filters-panel.collapsed {
         width: 100%;
         flex: 1 1 auto;
     }


### PR DESCRIPTION
## Summary
- remove the inline style panel from the results layout
- introduce a slide-in style menu with backdrop and close controls
- add an entry button and supporting styles for the new side navigation

## Testing
- Not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1071913e083298aec412a35195e1b