### PR TITLE
Add helper script to install the .NET SDK on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.dotnet/
+**/bin/
+**/obj/

--- a/README.txt
+++ b/README.txt
@@ -8,8 +8,9 @@ Deze repository bevat een Blazor WebAssembly-embed gebouwd met de MudBlazor comp
 
 ## Ontwikkeling
 1. Installeer .NET 8 SDK.
+   - Als de `dotnet` CLI niet beschikbaar is (bijvoorbeeld in een container), gebruik dan het hulpscript `./scripts/dotnet.sh`. Dit script downloadt automatisch een lokale SDK naar `.dotnet/` en voert het gevraagde `dotnet`-commando uit, bijvoorbeeld: `./scripts/dotnet.sh build src/Vendr.Embed/Vendr.Embed.csproj`.
 2. Navigeer naar `src/Vendr.Embed`.
-3. Voer `dotnet restore` en `dotnet build` uit.
+3. Voer `dotnet restore` en `dotnet build` uit (of gebruik het hulpscript hierboven).
 4. Start lokaal met `dotnet run` of publiceer met `dotnet publish -c Release`.
 
 De embed leest standaard `?realtor=` uit de URL en past thema, logo, filters en kaarten aan op basis van de datafeeds.

--- a/scripts/dotnet.sh
+++ b/scripts/dotnet.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOTNET_DIR="$REPO_ROOT/.dotnet"
+DOTNET_BIN="$DOTNET_DIR/dotnet"
+INSTALL_SCRIPT="$DOTNET_DIR/dotnet-install.sh"
+SDK_VERSION="${DOTNET_SDK_VERSION:-}"
+SDK_CHANNEL="${DOTNET_SDK_CHANNEL:-8.0}"
+
+ensure_dotnet() {
+  if [ -x "$DOTNET_BIN" ]; then
+    return
+  fi
+
+  mkdir -p "$DOTNET_DIR"
+  if [ ! -f "$INSTALL_SCRIPT" ]; then
+    curl -sSL https://dot.net/v1/dotnet-install.sh -o "$INSTALL_SCRIPT"
+    chmod +x "$INSTALL_SCRIPT"
+  fi
+
+  if [ -n "$SDK_VERSION" ]; then
+    "$INSTALL_SCRIPT" --version "$SDK_VERSION" --install-dir "$DOTNET_DIR" --no-path
+  else
+    "$INSTALL_SCRIPT" --channel "$SDK_CHANNEL" --install-dir "$DOTNET_DIR" --no-path
+  fi
+}
+
+ensure_dotnet
+exec "$DOTNET_BIN" "$@"


### PR DESCRIPTION
## Summary
- add a bootstrap script that downloads a local .NET SDK when the `dotnet` CLI is unavailable
- document the new helper script in the README so builds can run inside containers without a global installation
- ignore the locally installed SDK directory

## Testing
- `./scripts/dotnet.sh --version`
- `./scripts/dotnet.sh build src/Vendr.Embed/Vendr.Embed.csproj` *(fails: existing project compilation errors unrelated to CLI availability)*

------
https://chatgpt.com/codex/tasks/task_e_68e108d83afc83298fce84b5619d85fa