### PR TITLE
Add slide-out side menu to main layout

### DIFF
--- a/src/Vendr.Embed/Shared/MainLayout.razor
+++ b/src/Vendr.Embed/Shared/MainLayout.razor
@@ -2,15 +2,25 @@
 
 <MudLayout>
     <MudAppBar Elevation="0" Color="Color.Primary" Dense="true" DisableShrink="true">
-        <MudContainer Class="d-flex align-center justify-space-between" MaxWidth="MaxWidth.False">
-            @if (_headerContent is not null)
-            {
-                @_headerContent
-            }
-            else
-            {
-                <MudText Typo="Typo.h6">Vendr Embed</MudText>
-            }
+        <MudContainer Class="appbar-container" MaxWidth="MaxWidth.False">
+            <MudIconButton Icon="@Icons.Material.Filled.Menu"
+                           Color="Color.Inherit"
+                           Edge="Edge.Start"
+                           Class="side-menu-trigger"
+                           AriaLabel="Menu openen"
+                           AriaExpanded="@(_sideMenuOpen ? "true" : "false")"
+                           OnClick="OpenSideMenu" />
+
+            <div class="appbar-slot">
+                @if (_headerContent is not null)
+                {
+                    @_headerContent
+                }
+                else
+                {
+                    <MudText Typo="Typo.h6">Vendr Embed</MudText>
+                }
+            </div>
         </MudContainer>
     </MudAppBar>
 
@@ -23,12 +33,33 @@
     </MudMainContent>
 </MudLayout>
 
+<div class="side-menu-backdrop @(_sideMenuOpen ? "visible" : string.Empty)" @onclick="CloseSideMenu"></div>
+
+<nav class="side-menu @(_sideMenuOpen ? "open" : string.Empty)" aria-label="Hoofdmenu" aria-hidden="@(!_sideMenuOpen ? "true" : "false")">
+    <button type="button" class="closebtn" @onclick="CloseSideMenu" aria-label="Menu sluiten">&times;</button>
+    <a href="#over">Over</a>
+    <a href="#diensten">Diensten</a>
+    <a href="#klanten">Klanten</a>
+    <a href="#contact">Contact</a>
+</nav>
+
 @code {
     private RenderFragment? _headerContent;
+    private bool _sideMenuOpen;
 
     public void SetHeader(RenderFragment? fragment)
     {
         _headerContent = fragment;
         _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void OpenSideMenu()
+    {
+        _sideMenuOpen = true;
+    }
+
+    private void CloseSideMenu()
+    {
+        _sideMenuOpen = false;
     }
 }

--- a/src/Vendr.Embed/Shared/MainLayout.razor.css
+++ b/src/Vendr.Embed/Shared/MainLayout.razor.css
@@ -1,0 +1,88 @@
+.appbar-container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.appbar-slot {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.side-menu-trigger {
+    color: inherit;
+}
+
+.side-menu {
+    height: 100%;
+    width: 0;
+    position: fixed;
+    z-index: 1500;
+    top: 0;
+    left: 0;
+    background-color: #111;
+    overflow-x: hidden;
+    transition: width 0.3s ease;
+    padding-top: 64px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.side-menu.open {
+    width: min(260px, 80vw);
+}
+
+.side-menu a {
+    padding: 0.5rem 2rem;
+    text-decoration: none;
+    font-size: 1.25rem;
+    color: #818181;
+    display: block;
+    transition: color 0.3s ease;
+}
+
+.side-menu a:hover,
+.side-menu a:focus-visible {
+    color: #f1f1f1;
+}
+
+.side-menu .closebtn {
+    position: absolute;
+    top: 16px;
+    right: 24px;
+    font-size: 2rem;
+    margin-left: 50px;
+    background: transparent;
+    border: none;
+    color: #f1f1f1;
+    cursor: pointer;
+}
+
+.side-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 1400;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.side-menu-backdrop.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+@media screen and (max-height: 450px) {
+    .side-menu {
+        padding-top: 48px;
+    }
+
+    .side-menu a {
+        font-size: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a hamburger trigger in the app bar that opens a slide-out navigation drawer with example links
- provide a backdrop and close affordances to mirror the requested side menu behaviour
- scope new styling for the layout, navigation drawer, and overlay to the main layout component

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e109fd63048329a1b605b409b361ff