### PR TITLE
Add hamburger trigger to open the side menu

### DIFF
--- a/src/Vendr.Embed/Pages/Index.razor
+++ b/src/Vendr.Embed/Pages/Index.razor
@@ -21,6 +21,18 @@ else if (!string.IsNullOrEmpty(_error))
 else
 {
     <MudStack Spacing="3">
+        @if (Layout is not null)
+        {
+            <MudTooltip Text="Hoofdmenu openen">
+                <MudIconButton Icon="@Icons.Material.Filled.Menu"
+                               Color="Color.Primary"
+                               Size="Size.Medium"
+                               Class="page-menu-trigger"
+                               AriaLabel="Hoofdmenu openen"
+                               OnClick="OpenHamburgerMenu" />
+            </MudTooltip>
+        }
+
         <MudStack Row="true" AlignItems="AlignItems.Stretch" Spacing="2" Class="layout-root">
             <MudPaper Class="@($"filters-panel pa-4{(_filtersCollapsed ? " collapsed" : string.Empty)}")" Elevation="1">
                 <MudStack Spacing="1.5">
@@ -457,6 +469,11 @@ else
             _secondaryColor = value;
             _ = ApplyCurrentPaletteAsync();
         }
+    }
+
+    private void OpenHamburgerMenu()
+    {
+        Layout?.OpenSideMenu();
     }
 
     private void ToggleFilters()

--- a/src/Vendr.Embed/Pages/Index.razor.css
+++ b/src/Vendr.Embed/Pages/Index.razor.css
@@ -47,6 +47,10 @@
     font-weight: 600;
 }
 
+.page-menu-trigger {
+    align-self: flex-start;
+}
+
 
 .main-toolbar {
     gap: 1rem;

--- a/src/Vendr.Embed/Shared/MainLayout.razor
+++ b/src/Vendr.Embed/Shared/MainLayout.razor
@@ -53,7 +53,7 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private void OpenSideMenu()
+    public void OpenSideMenu()
     {
         _sideMenuOpen = true;
     }


### PR DESCRIPTION
## Summary
- expose the side menu open method on the layout so it can be triggered externally
- add a hamburger icon button on the main page that opens the side menu through the layout
- style the new trigger button to align with the page layout

## Testing
- Not run (dotnet CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e10b76f5f08329bf2d2e922144cd80