### PR TITLE
Add visible hamburger button to header

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -194,6 +194,28 @@ header, .header--neutral, .header-bar { transform: translateZ(0); }
   gap: 18px;
 }
 
+.hamburger {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 44px;
+  height: 44px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 100%;
+  height: 3px;
+  background: #0f172a;
+  border-radius: 999px;
+}
+
 .brand img {
   height: 40px;
   display: block;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,11 @@
   <!-- Sticky Header (neutrale stijl) -->
   <header class="header--neutral">
     <div class="container header-bar">
+      <button class="hamburger" type="button" aria-label="Open navigatie" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
       <a href="#" id="realtorLink" class="brand" aria-label="Naar website makelaar">
         <img id="realtorLogo" src="" alt="Realtor logo" />
       </a>


### PR DESCRIPTION
## Summary
- add a hamburger menu button to the header markup so it appears at the top left
- style the hamburger button to match the header design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10ebe62c48329964591d9710d6c76