### PR TITLE
Enable hamburger button to toggle navigation menu

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -245,6 +245,65 @@ header, .header--neutral, .header-bar { transform: translateZ(0); }
   font: 0.9em 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
 }
 
+.header-menu {
+  border-top: 1px solid var(--border);
+  background: #fff;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.header-menu__inner {
+  padding-top: 0;
+  padding-bottom: 20px;
+}
+
+.header-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header-menu__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: #0f172a;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.header-menu__link:hover,
+.header-menu__link:focus {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent);
+  outline: none;
+}
+
+.header--neutral.menu-open .hamburger {
+  border-color: rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.header--neutral.menu-open .hamburger span {
+  background: var(--accent);
+}
+
+@media (min-width: 960px) {
+  .header-menu__list {
+    flex-direction: row;
+    padding: 16px 0;
+  }
+
+  .header-menu__link {
+    padding: 8px 10px;
+  }
+}
+
 /* Alerts & Stats */
 .alert {
   border: 1px solid #7f1d1d;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -14,6 +14,54 @@ let $themeLink    = document.getElementById('themeStylesheet');
 let $defaultThemeLink = document.getElementById('defaultThemeStylesheet');
 const $stylePanel = document.querySelector('.style-panel');
 const $mainThemed = document.querySelector('main.container.themed');
+const $header     = document.querySelector('.header--neutral');
+const $hamburger  = document.querySelector('.hamburger');
+const $menu       = document.getElementById('primaryNavigation');
+
+function initHamburgerMenu() {
+  if (!$header || !$hamburger || !$menu) return;
+
+  const setMenuState = (open) => {
+    const isOpen = Boolean(open);
+    $header.classList.toggle('menu-open', isOpen);
+    $menu.hidden = !isOpen;
+    $hamburger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  };
+
+  setMenuState(false);
+
+  $hamburger.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const open = !$header.classList.contains('menu-open');
+    setMenuState(open);
+  });
+
+  $menu.addEventListener('click', (event) => {
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest('a')) {
+      setMenuState(false);
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!$header.classList.contains('menu-open')) return;
+    if ($header.contains(event.target)) return;
+    setMenuState(false);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && $header.classList.contains('menu-open')) {
+      setMenuState(false);
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initHamburgerMenu, { once: true });
+} else {
+  initHamburgerMenu();
+}
 
 const DEFAULT_THEME_STYLESHEET = 'assets/css/themes/default.css';
 const OVERRIDE_STYLES = `

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   <!-- Sticky Header (neutrale stijl) -->
   <header class="header--neutral">
     <div class="container header-bar">
-      <button class="hamburger" type="button" aria-label="Open navigatie" aria-expanded="false">
+      <button class="hamburger" type="button" aria-label="Open navigatie" aria-expanded="false" aria-controls="primaryNavigation">
         <span></span>
         <span></span>
         <span></span>
@@ -68,6 +68,15 @@
         </label>
       </div>
     </div>
+    <nav id="primaryNavigation" class="header-menu" aria-label="Hoofdmenu" hidden>
+      <div class="header-menu__inner container">
+        <ul class="header-menu__list">
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Overzicht</a></li>
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Collecties</a></li>
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Instellingen</a></li>
+        </ul>
+      </div>
+    </nav>
   </header>
 
   <!-- Main content (themed) -->


### PR DESCRIPTION
## Summary
- add a primary navigation menu with placeholder links and connect it to the hamburger control
- style the revealed menu and active hamburger state for both mobile and desktop breakpoints
- implement JavaScript to toggle the menu, manage focus interactions, and close on outside clicks or Escape

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e110c9a30883299ae73f6312a76613