### PR TITLE
Move hamburger control into themed container

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -41,6 +41,13 @@ main.container.themed {
   --font-heading: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
   --font-label: var(--font-body);
   --font-button: var(--font-body);
+  display: flex;
+  flex-direction: column;
+}
+
+main.container.themed > .hamburger {
+  align-self: flex-start;
+  margin-bottom: 16px;
 }
 
 .themed-layout {

--- a/index.html
+++ b/index.html
@@ -34,11 +34,6 @@
   <!-- Sticky Header (neutrale stijl) -->
   <header class="header--neutral">
     <div class="container header-bar">
-      <button class="hamburger" type="button" aria-label="Open navigatie" aria-expanded="false" aria-controls="primaryNavigation">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
       <a href="#" id="realtorLink" class="brand" aria-label="Naar website makelaar">
         <img id="realtorLogo" src="" alt="Realtor logo" />
       </a>
@@ -82,6 +77,11 @@
 
   <!-- Main content (themed) -->
   <main class="container themed" id="main">
+    <button class="hamburger" type="button" aria-label="Open navigatie" aria-expanded="false" aria-controls="primaryNavigation">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
     <div class="themed-layout">
       <aside class="style-panel" aria-labelledby="style-panel-title">
         <div class="style-panel__intro">


### PR DESCRIPTION
## Summary
- move the hamburger button out of the header bar and into the themed container so it appears at the top-left of the main content
- update themed container layout styles so the relocated button aligns at the start of the column with appropriate spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12394312883299923deee389f9ad9