### PR TITLE
Scope side menu to main container

### DIFF
--- a/src/Vendr.Embed/Shared/MainLayout.razor
+++ b/src/Vendr.Embed/Shared/MainLayout.razor
@@ -25,23 +25,25 @@
     </MudAppBar>
 
     <MudMainContent>
-        <MudContainer Class="py-6" MaxWidth="MaxWidth.False">
-            <CascadingValue Value="this">
-                @Body
-            </CascadingValue>
-        </MudContainer>
+        <div class="main-container-themed">
+            <MudContainer Class="py-6" MaxWidth="MaxWidth.False">
+                <CascadingValue Value="this">
+                    @Body
+                </CascadingValue>
+            </MudContainer>
+
+            <div class="side-menu-backdrop @(_sideMenuOpen ? "visible" : string.Empty)" @onclick="CloseSideMenu"></div>
+
+            <nav class="side-menu @(_sideMenuOpen ? "open" : string.Empty)" aria-label="Hoofdmenu" aria-hidden="@(!_sideMenuOpen ? "true" : "false")">
+                <button type="button" class="closebtn" @onclick="CloseSideMenu" aria-label="Menu sluiten">&times;</button>
+                <a href="#over">Over</a>
+                <a href="#diensten">Diensten</a>
+                <a href="#klanten">Klanten</a>
+                <a href="#contact">Contact</a>
+            </nav>
+        </div>
     </MudMainContent>
 </MudLayout>
-
-<div class="side-menu-backdrop @(_sideMenuOpen ? "visible" : string.Empty)" @onclick="CloseSideMenu"></div>
-
-<nav class="side-menu @(_sideMenuOpen ? "open" : string.Empty)" aria-label="Hoofdmenu" aria-hidden="@(!_sideMenuOpen ? "true" : "false")">
-    <button type="button" class="closebtn" @onclick="CloseSideMenu" aria-label="Menu sluiten">&times;</button>
-    <a href="#over">Over</a>
-    <a href="#diensten">Diensten</a>
-    <a href="#klanten">Klanten</a>
-    <a href="#contact">Contact</a>
-</nav>
 
 @code {
     private RenderFragment? _headerContent;

--- a/src/Vendr.Embed/Shared/MainLayout.razor.css
+++ b/src/Vendr.Embed/Shared/MainLayout.razor.css
@@ -1,3 +1,15 @@
+.main-container-themed {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}
+
+.main-container-themed > .mud-container {
+    position: relative;
+    z-index: 0;
+}
+
 .appbar-container {
     display: flex;
     align-items: center;
@@ -17,23 +29,26 @@
 }
 
 .side-menu {
-    height: 100%;
-    width: 0;
-    position: fixed;
-    z-index: 1500;
+    position: absolute;
     top: 0;
+    bottom: 0;
     left: 0;
+    z-index: 20;
     background-color: #111;
     overflow-x: hidden;
-    transition: width 0.3s ease;
-    padding-top: 64px;
+    padding: 64px 0 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    width: min(260px, 100%);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    pointer-events: none;
 }
 
 .side-menu.open {
-    width: min(260px, 80vw);
+    transform: translateX(0);
+    pointer-events: auto;
 }
 
 .side-menu a {
@@ -63,10 +78,10 @@
 }
 
 .side-menu-backdrop {
-    position: fixed;
+    position: absolute;
     inset: 0;
     background: rgba(0, 0, 0, 0.45);
-    z-index: 1400;
+    z-index: 10;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.3s ease;


### PR DESCRIPTION
## Summary
- move the primary navigation markup inside the themed main container so it opens within the intended context
- restyle the side menu and backdrop to use container-relative positioning and span the full main container height

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1309ddae48329ae12df3dba141791