### PR TITLE
Move primary navigation into main container

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,12 +23,14 @@ function initHamburgerMenu() {
 
   const focusableSelector = 'a[href]:not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 
-  let $backdrop = $header.querySelector('.header-menu__backdrop');
-  if (!$backdrop) {
+  const menuHost = $menu.parentElement || $header || document.body;
+
+  let $backdrop = menuHost.querySelector('.header-menu__backdrop');
+  if (!$backdrop || $backdrop.parentElement !== menuHost) {
     $backdrop = document.createElement('div');
     $backdrop.className = 'header-menu__backdrop';
     $backdrop.setAttribute('aria-hidden', 'true');
-    $header.insertBefore($backdrop, $menu);
+    menuHost.insertBefore($backdrop, $menu);
   }
 
   const $closeButton = $menu.querySelector('.header-menu__close');

--- a/index.html
+++ b/index.html
@@ -63,16 +63,6 @@
         </label>
       </div>
     </div>
-    <nav id="primaryNavigation" class="header-menu" aria-label="Hoofdmenu" aria-hidden="true">
-      <button class="header-menu__close" type="button" aria-label="Menu sluiten">&times;</button>
-      <div class="header-menu__inner">
-        <ul class="header-menu__list">
-          <li class="header-menu__item"><a class="header-menu__link" href="#">Overzicht</a></li>
-          <li class="header-menu__item"><a class="header-menu__link" href="#">Collecties</a></li>
-          <li class="header-menu__item"><a class="header-menu__link" href="#">Instellingen</a></li>
-        </ul>
-      </div>
-    </nav>
   </header>
 
   <!-- Main content (themed) -->
@@ -82,6 +72,16 @@
       <span></span>
       <span></span>
     </button>
+    <nav id="primaryNavigation" class="header-menu open" aria-label="Hoofdmenu" aria-hidden="false">
+      <button class="header-menu__close" type="button" aria-label="Menu sluiten">×</button>
+      <div class="header-menu__inner">
+        <ul class="header-menu__list">
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Overzicht</a></li>
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Collecties</a></li>
+          <li class="header-menu__item"><a class="header-menu__link" href="#">Instellingen</a></li>
+        </ul>
+      </div>
+    </nav>
     <div class="themed-layout">
       <aside class="style-panel" aria-labelledby="style-panel-title">
         <div class="style-panel__intro">


### PR DESCRIPTION
## Summary
- relocate the primary navigation markup from the header into the main container
- adjust hamburger menu setup so the backdrop anchors to the menu's new parent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e133fb79248329a3068fb10f318300