### PR TITLE
Ensure header menu has minimum width and remove backdrop overlay

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -257,21 +257,6 @@ body.has-menu-open {
   font: 0.9em 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
 }
 
-.header-menu__backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.45);
-  z-index: 3995;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-
-.header-menu__backdrop.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 .header-menu {
   position: fixed;
   inset: 0 auto 0 0;
@@ -290,7 +275,8 @@ body.has-menu-open {
 }
 
 .header-menu.open {
-  width: min(320px, 85vw);
+  width: min(max(600px, 85vw), 100vw);
+  min-width: 600px;
   box-shadow: 18px 0 32px rgba(15, 23, 42, 0.25);
   pointer-events: auto;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,14 +23,10 @@ function initHamburgerMenu() {
 
   const focusableSelector = 'a[href]:not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 
-  const menuHost = $menu.parentElement || $header || document.body;
-
-  let $backdrop = menuHost.querySelector('.header-menu__backdrop');
-  if (!$backdrop || $backdrop.parentElement !== menuHost) {
-    $backdrop = document.createElement('div');
-    $backdrop.className = 'header-menu__backdrop';
-    $backdrop.setAttribute('aria-hidden', 'true');
-    menuHost.insertBefore($backdrop, $menu);
+  const menuParent = $menu.parentElement;
+  const existingBackdrop = menuParent?.querySelector('.header-menu__backdrop');
+  if (existingBackdrop && existingBackdrop.parentElement) {
+    existingBackdrop.parentElement.removeChild(existingBackdrop);
   }
 
   const $closeButton = $menu.querySelector('.header-menu__close');
@@ -49,10 +45,6 @@ function initHamburgerMenu() {
     $menu.classList.toggle('open', isOpen);
     $menu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
     $hamburger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    if ($backdrop) {
-      $backdrop.classList.toggle('visible', isOpen);
-      $backdrop.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-    }
     applyScrollLock(isOpen);
 
     const stateChanged = wasOpen !== isOpen;
@@ -104,14 +96,6 @@ function initHamburgerMenu() {
 
   if ($closeButton) {
     $closeButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      closeMenu();
-    });
-  }
-
-  if ($backdrop) {
-    $backdrop.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
       closeMenu();


### PR DESCRIPTION
## Summary
- enforce a 600px minimum width for the header menu while respecting viewport limits
- remove the header menu backdrop styles and associated runtime logic so the menu stays unobstructed when opened

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e139e81d6c8329b1ffe6225b73705c