### PR TITLE
Adjust header and side menu styling

### DIFF
--- a/src/Vendr.Embed/Shared/MainLayout.razor
+++ b/src/Vendr.Embed/Shared/MainLayout.razor
@@ -1,7 +1,7 @@
 @inherits LayoutComponentBase
 
 <MudLayout>
-    <MudAppBar Elevation="0" Color="Color.Primary" Dense="true" DisableShrink="true">
+    <MudAppBar Elevation="0" Color="Color.Default" Dense="true" DisableShrink="true" Class="main-appbar">
         <MudContainer Class="appbar-container" MaxWidth="MaxWidth.False">
             <MudIconButton Icon="@Icons.Material.Filled.Menu"
                            Color="Color.Inherit"

--- a/src/Vendr.Embed/Shared/MainLayout.razor.css
+++ b/src/Vendr.Embed/Shared/MainLayout.razor.css
@@ -10,6 +10,11 @@
     z-index: 0;
 }
 
+.mud-appbar.main-appbar {
+    background-color: #ffffff;
+    color: #313233;
+}
+
 .appbar-container {
     display: flex;
     align-items: center;
@@ -34,13 +39,13 @@
     bottom: 0;
     left: 0;
     z-index: 20;
-    background-color: #111;
+    background-color: #ffffff;
     overflow-x: hidden;
     padding: 64px 0 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    width: min(260px, 100%);
+    width: min(500px, 30vw);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     pointer-events: none;
@@ -55,14 +60,14 @@
     padding: 0.5rem 2rem;
     text-decoration: none;
     font-size: 1.25rem;
-    color: #818181;
+    color: #313233;
     display: block;
     transition: color 0.3s ease;
 }
 
 .side-menu a:hover,
 .side-menu a:focus-visible {
-    color: #f1f1f1;
+    color: #111111;
 }
 
 .side-menu .closebtn {
@@ -73,7 +78,7 @@
     margin-left: 50px;
     background: transparent;
     border: none;
-    color: #f1f1f1;
+    color: #313233;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- set the header app bar background to white and align its text color
- update the side menu styling to use the requested width and menu link colors

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1419bf6a08329bce56432a746c3e2