### PR TITLE
Adjust side menu width to 40% max

### DIFF
--- a/src/Vendr.Embed/Shared/MainLayout.razor.css
+++ b/src/Vendr.Embed/Shared/MainLayout.razor.css
@@ -45,7 +45,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    width: min(500px, 30vw);
+    width: min(500px, 40vw);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- update the side menu styling to use a 500px width capped at 40% of the viewport width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1445e92248329bd9912927da7c6a0