### PR TITLE
Adjust menu layering and spacing

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -266,7 +266,7 @@ body.has-menu-open {
   color: #313233;
   overflow: hidden;
   overflow-y: auto;
-  padding: 96px 0 32px;
+  padding: 168px 0 32px;
   box-shadow: none;
   transition: width 0.3s ease;
   z-index: 4002;
@@ -320,7 +320,7 @@ body.has-menu-open {
 
 .header-menu__close {
   position: absolute;
-  top: 24px;
+  top: 96px;
   right: 24px;
   width: 44px;
   height: 44px;

--- a/src/Vendr.Embed/Shared/MainLayout.razor.css
+++ b/src/Vendr.Embed/Shared/MainLayout.razor.css
@@ -38,7 +38,7 @@
     top: 0;
     bottom: 0;
     left: 0;
-    z-index: 20;
+    z-index: 3999;
     background-color: #ffffff;
     overflow-x: hidden;
     padding: 64px 0 1rem;


### PR DESCRIPTION
## Summary
- raise the side menu z-index so it sits above overlapping elements
- increase the header menu padding to push content lower on the page
- move the header menu close button to align with the new spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14af1cf6083299dd3e7ee2d0dd245