### PR TITLE
Adjust side menu z-index

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -269,7 +269,7 @@ body.has-menu-open {
   padding: 168px 0 32px;
   box-shadow: none;
   transition: width 0.3s ease;
-  z-index: 4002;
+  z-index: 3999;
   box-sizing: border-box;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- update the fixed header side menu layer order by lowering its z-index from 4002 to 3999

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14c87e78c8329a264f650c97fc4d6