### PR TITLE
Set border to zero for color picker inputs

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -137,7 +137,7 @@ main.container.themed > .hamburger {
   width: 100%;
   height: 36px;
   padding: 0;
-  border: 1px solid var(--border);
+  border: 0;
   border-radius: 8px;
   background: #fff;
 }


### PR DESCRIPTION
## Summary
- remove the visible border from style panel color input fields by setting border to 0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16d66d6dc83298e4659fd5e3b12e4