### PR TITLE
Align style toggle label and checkbox layout

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -174,9 +174,26 @@ main.container.themed > .hamburger {
   color: #1f2937;
 }
 
+.style-panel__toggle span {
+  justify-self: start;
+}
+
 .style-panel__toggle input {
   width: 18px;
   height: 18px;
+}
+
+@media (min-width: 640px) {
+  .style-panel__toggle {
+    display: grid;
+    grid-template-columns: var(--style-panel-label-width) auto;
+    column-gap: 16px;
+    align-items: center;
+  }
+
+  .style-panel__toggle input {
+    justify-self: start;
+  }
 }
 
 @media (max-width: 1024px) {

--- a/index.html
+++ b/index.html
@@ -260,8 +260,8 @@
               </label>
 
               <label class="style-panel__toggle" for="styleOutline">
-                <input type="checkbox" id="styleOutline" checked />
                 <span>Rand zichtbaar</span>
+                <input type="checkbox" id="styleOutline" checked />
               </label>
             </fieldset>
           </form>


### PR DESCRIPTION
## Summary
- place the toggle label text before its checkbox so the two columns can align
- add responsive styling that switches the toggle to a grid layout on wide screens, keeping the label in the left column and checkbox in the right column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16e0b2e7883299c1b296677ef3f9d