### PR TITLE
Remove important flag from default theme

### DIFF
--- a/assets/css/themes/default.css
+++ b/assets/css/themes/default.css
@@ -119,7 +119,7 @@ main.container.themed .card .media span.badge {
   top: 10px;
   background-color: var(--c-pill);
   padding: 3px 10px;
-  color: #FFF !important;
+  color: #FFF;
   font-family: var(--font-body);
   font-size: 1rem;
   font-weight: var(--fw-bold);


### PR DESCRIPTION
## Summary
- remove the `!important` flag from the default theme badge color rule to allow normal cascade behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3940cde6c83299eb5bce3595d8a35