### PR TITLE
Ensure realtor theme stylesheet loads last

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -266,6 +266,7 @@ let FILTERED = [];
 let CURRENT_MEDIA_RATIO = null;
 
 function ensureOverrideStyles() {
+  ensureThemeLinkPriority();
   if (!$mainThemed) return null;
   if (!overrideStyleEl) {
     overrideStyleEl = document.getElementById('themeStyleOverrides') || document.createElement('style');
@@ -282,6 +283,36 @@ function ensureOverrideStyles() {
     parent.appendChild(overrideStyleEl);
   }
   return overrideStyleEl;
+}
+
+function ensureThemeLinkPriority() {
+  if (!$themeLink) {
+    return;
+  }
+
+  const head = document.head || document.getElementsByTagName('head')[0];
+  if (!head) {
+    return;
+  }
+
+  if ($themeLink.parentNode !== head) {
+    head.appendChild($themeLink);
+  }
+
+  const stylesheetLinks = Array.from(head.querySelectorAll('link[rel~="stylesheet"]'));
+  if (!stylesheetLinks.length) {
+    return;
+  }
+
+  const lastLink = stylesheetLinks[stylesheetLinks.length - 1];
+  if (lastLink !== $themeLink) {
+    const currentParent = $themeLink.parentNode;
+    if (currentParent) {
+      currentParent.removeChild($themeLink);
+    }
+    const insertionParent = document.head || head;
+    insertionParent.insertBefore($themeLink, lastLink.nextSibling);
+  }
 }
 
 async function ensureDefaultThemeStylesheet() {
@@ -1131,6 +1162,8 @@ async function swapThemeStylesheet(href) {
     $themeLink.id = 'themeStylesheet';
     document.head.appendChild($themeLink);
   }
+
+  ensureThemeLinkPriority();
 
   const previous = $themeLink.getAttribute('href');
   const absolutePrev = previous ? new URL(previous, location.href).href : null;


### PR DESCRIPTION
## Summary
- ensure the realtor-specific theme link is always appended after other stylesheets so it wins the cascade
- reposition override styles after moving the theme link to keep runtime overrides intact

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3b369a9c883299e086725ec381531