### PR TITLE
Fix badge color fallback to use realtor theme settings

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -72,7 +72,7 @@ main.container.themed {
   --badge-offset: 12px;
   --badge-radius: 4px;
   --badge-text: #ffffff;
-  --badge-color: #ff0000;
+  --badge-color: var(--c-pill, #ff0000);
   --button-padding: 14px;
   --button-offset: 16px;
   --button-radius: 40px;
@@ -526,7 +526,7 @@ body.has-menu-open {
   border-radius: var(--badge-radius, 4px);
   font-weight: 700;
   font-size: 12px;
-  background: var(--badge-color, #ff0000);
+  background: var(--badge-color, var(--c-pill, #ff0000));
   color: var(--badge-text, #052e16);
   font-family: var(--font-label, var(--font-body));
   z-index: 0;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -228,7 +228,7 @@ main.container.themed .card .media .badge {
   top: var(--badge-offset, 12px);
   padding: calc(var(--badge-padding, 10px) * 0.6) var(--badge-padding, 10px);
   border-radius: var(--badge-radius, 4px);
-  background: var(--badge-color, #22c55e);
+  background: var(--badge-color, var(--c-pill, #22c55e));
   color: var(--badge-text, #052e16) !important;
   font-family: var(--font-label, var(--font-body, 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial));
 }


### PR DESCRIPTION
## Summary
- let the base badge color variable defer to the realtor theme pill color so realtor styles apply automatically
- update the runtime override styles to fall back to `--c-pill` when no badge color is explicitly set

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bfead8288329bd27d1a8755c7e7d